### PR TITLE
Makes timestamp optional on Span::finish.

### DIFF
--- a/src/Zipkin/Annotation.php
+++ b/src/Zipkin/Annotation.php
@@ -30,7 +30,7 @@ final class Annotation
 
     /**
      * @param string $value
-     * @param float $timestamp
+     * @param int $timestamp
      * @throws InvalidArgumentException on empty or not stringable value or invalid timestamp
      * @return Annotation
      */

--- a/src/Zipkin/NoopSpan.php
+++ b/src/Zipkin/NoopSpan.php
@@ -65,7 +65,7 @@ final class NoopSpan implements Span
 
     /**
      * The kind of span is optional. When set, it affects how a span is reported. For example, if the
-     * kind is {@link Kind#SERVER}, the span's start timestamp is implicitly annotated as "sr"
+     * kind is {@link Zipkin\Kind\SERVER}, the span's start timestamp is implicitly annotated as "sr"
      * and that plus its duration as "ss".
      *
      * @param string $kind
@@ -87,20 +87,18 @@ final class NoopSpan implements Span
      */
     public function setTag($key, $value)
     {
-        // TODO: Implement setTag() method.
     }
 
     /**
      * Associates an event that explains latency with the current system time.
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
-     * @param float $timestamp
+     * @param int $timestamp
      * @return void
      * @see Annotation
      */
     public function annotate($value, $timestamp)
     {
-        // TODO: Implement annotate() method.
     }
 
     /**
@@ -130,10 +128,10 @@ final class NoopSpan implements Span
      * {@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
      * timestamp from this, and set when appropriate.
      *
-     * @param float $timestamp
+     * @param int|null $timestamp
      * @return void
      */
-    public function finish($timestamp)
+    public function finish($timestamp = null)
     {
     }
 

--- a/src/Zipkin/RealSpan.php
+++ b/src/Zipkin/RealSpan.php
@@ -59,7 +59,7 @@ final class RealSpan implements Span
      * Spans can be modified before calling start. For example, you can add tags to the span and
      * set its name without lock contention.
      *
-     * @param float $timestamp
+     * @param int $timestamp
      * @return void
      * @throws \InvalidArgumentException
      */
@@ -98,7 +98,7 @@ final class RealSpan implements Span
 
     /**
      * The kind of span is optional. When set, it affects how a span is reported. For example, if the
-     * kind is {@link Kind#SERVER}, the span's start timestamp is implicitly annotated as "sr"
+     * kind is {@link Zipkin\Kind\SERVER}, the span's start timestamp is implicitly annotated as "sr"
      * and that plus its duration as "ss".
      *
      * @param string $kind
@@ -178,14 +178,18 @@ final class RealSpan implements Span
      * {@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
      * timestamp from this, and set when appropriate.
      *
-     * @param float $timestamp
+     * @param int|null $timestamp
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function finish($timestamp)
+    public function finish($timestamp = null)
     {
-        if (!Timestamp\is_valid_timestamp($timestamp)) {
+        if ($timestamp !== null && !Timestamp\is_valid_timestamp($timestamp)) {
             throw new InvalidArgumentException('Invalid timestamp');
+        }
+
+        if ($timestamp === null) {
+            $timestamp = Timestamp\now();
         }
 
         $this->recorder->finish($this->traceContext, $timestamp);

--- a/src/Zipkin/Recorder.php
+++ b/src/Zipkin/Recorder.php
@@ -65,7 +65,7 @@ class Recorder
 
     /**
      * @param TraceContext $context
-     * @param float $timestamp
+     * @param int $timestamp
      */
     public function start(TraceContext $context, $timestamp)
     {

--- a/src/Zipkin/Span.php
+++ b/src/Zipkin/Span.php
@@ -24,7 +24,7 @@ interface Span
      * Spans can be modified before calling start. For example, you can add tags to the span and
      * set its name without lock contention.
      *
-     * @param float $timestamp
+     * @param int|null $timestamp
      * @return void
      */
     public function start($timestamp = null);
@@ -39,7 +39,7 @@ interface Span
 
     /**
      * The kind of span is optional. When set, it affects how a span is reported. For example, if the
-     * kind is {@link Kind#SERVER}, the span's start timestamp is implicitly annotated as "sr"
+     * kind is {@link Zipkin\Kind\SERVER}, the span's start timestamp is implicitly annotated as "sr"
      * and that plus its duration as "ss".
      *
      * The value must be strictly one of the ones listed in {@link Kind}.
@@ -65,7 +65,7 @@ interface Span
      * Associates an event that explains latency with the current system time.
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
-     * @param float $timestamp
+     * @param int $timestamp
      * @return void
      * @see Annotation
      */
@@ -94,10 +94,10 @@ interface Span
      * {@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
      * timestamp from this, and set when appropriate.
      *
-     * @param float $timestamp
+     * @param int|null $timestamp
      * @return void
      */
-    public function finish($timestamp);
+    public function finish($timestamp = null);
 
     /**
      * Reports the span, even if unfinished. Most users will not call this method.


### PR DESCRIPTION
For the sake of convenience, the `$timestamp` parameter becomes optional, making it `Timestamp\now()` its default value same as `brave`.

Ping @beberlei