### PR TITLE
Final tweaks on the TraceContext and SamplingFlags.

### DIFF
--- a/src/Zipkin/Propagation/B3.php
+++ b/src/Zipkin/Propagation/B3.php
@@ -88,7 +88,7 @@ final class B3 implements Propagation
         return function ($carrier) use ($getter) {
             $sampledString = $getter->get($carrier, self::SAMPLED_NAME);
 
-            $isSampled = null;
+            $isSampled = SamplingFlags::EMPTY_SAMPLED;
             if ($sampledString === '1' || strtolower($sampledString) === 'true') {
                 $isSampled = true;
             } elseif ($sampledString === '0' || strtolower($sampledString) === 'false') {
@@ -96,7 +96,9 @@ final class B3 implements Propagation
             }
 
             $isDebug = $getter->get($carrier, self::FLAGS_NAME);
-            if ($isDebug !== null) {
+            if ($isDebug === null) {
+                $isDebug = SamplingFlags::EMPTY_DEBUG;
+            } else {
                 $isDebug = ($isDebug === '1');
             }
 

--- a/src/Zipkin/Propagation/DefaultSamplingFlags.php
+++ b/src/Zipkin/Propagation/DefaultSamplingFlags.php
@@ -6,9 +6,6 @@ use InvalidArgumentException;
 
 final class DefaultSamplingFlags implements SamplingFlags
 {
-    const EMPTY_SAMPLED = null;
-    const EMPTY_DEBUG = false;
-
     /**
      * @var bool|null
      */
@@ -26,22 +23,24 @@ final class DefaultSamplingFlags implements SamplingFlags
     }
 
     /**
-     * @param bool $sampled
-     * @param bool $debug
+     * @param bool|null $isSampled
+     * @param bool $isDebug
      * @throws InvalidArgumentException
      * @return DefaultSamplingFlags
      */
-    public static function create($sampled, $debug = false)
+    public static function create($isSampled, $isDebug = false)
     {
-        if ($sampled !== null && $sampled !== (bool) $sampled) {
-            throw new InvalidArgumentException(sprintf('sampled should be boolean, got %s', gettype($sampled)));
+        if ($isSampled !== null && $isSampled !== (bool) $isSampled) {
+            throw new InvalidArgumentException(
+                sprintf('isSampled should be boolean or null, got %s', gettype($isSampled))
+            );
         }
 
-        if ($debug !== (bool) $debug) {
-            throw new InvalidArgumentException(sprintf('debug should be boolean, got %s', gettype($debug)));
+        if ($isDebug !== (bool) $isDebug) {
+            throw new InvalidArgumentException(sprintf('isDebug should be boolean, got %s', gettype($isDebug)));
         }
 
-        return new self($sampled, $debug);
+        return new self($isSampled, $isDebug);
     }
 
     /**
@@ -49,7 +48,7 @@ final class DefaultSamplingFlags implements SamplingFlags
      */
     public static function createAsEmpty()
     {
-        return new self(self::EMPTY_SAMPLED, self::EMPTY_DEBUG);
+        return new self(SamplingFlags::EMPTY_SAMPLED, SamplingFlags::EMPTY_DEBUG);
     }
 
     /**
@@ -100,14 +99,5 @@ final class DefaultSamplingFlags implements SamplingFlags
     {
         return $this->isDebug() === $samplingFlags->isDebug()
             && $this->isSampled() === $samplingFlags->isSampled();
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return $this->isSampled === self::EMPTY_SAMPLED
-            && $this->isDebug === self::EMPTY_DEBUG;
     }
 }

--- a/src/Zipkin/Propagation/SamplingFlags.php
+++ b/src/Zipkin/Propagation/SamplingFlags.php
@@ -4,6 +4,9 @@ namespace Zipkin\Propagation;
 
 interface SamplingFlags
 {
+    const EMPTY_SAMPLED = null;
+    const EMPTY_DEBUG = false;
+
     /**
      * @return bool|null
      */
@@ -13,11 +16,6 @@ interface SamplingFlags
      * @return bool
      */
     public function isDebug();
-
-    /**
-     * @return bool
-     */
-    public function isEmpty();
 
     /**
      * @param SamplingFlags $samplingFlags

--- a/src/Zipkin/Propagation/TraceContext.php
+++ b/src/Zipkin/Propagation/TraceContext.php
@@ -8,11 +8,8 @@ use Zipkin\Propagation\SamplingFlags;
 
 final class TraceContext implements SamplingFlags
 {
-    const EMPTY_SAMPLED = null;
-    const EMPTY_DEBUG = false;
-
     /**
-     * @var bool
+     * @var bool|null
      */
     private $isSampled;
 
@@ -65,8 +62,8 @@ final class TraceContext implements SamplingFlags
         $traceId,
         $spanId,
         $parentId = null,
-        $isSampled = null,
-        $isDebug = false,
+        $isSampled = SamplingFlags::EMPTY_SAMPLED,
+        $isDebug = SamplingFlags::EMPTY_DEBUG,
         $usesTraceId128bits = false
     ) {
         if (!self::isValidTraceId($traceId)) {
@@ -79,6 +76,16 @@ final class TraceContext implements SamplingFlags
 
         if ($parentId !== null && !self::isValidSpanId($parentId)) {
             throw new InvalidArgumentException(sprintf('Invalid parent span id, got %s', $parentId));
+        }
+
+        if ($isSampled !== null && $isSampled !== (bool) $isSampled) {
+            throw new InvalidArgumentException(
+                sprintf('is Sampled should be boolean or null, got %s', gettype($isSampled))
+            );
+        }
+
+        if ($isDebug !== (bool) $isDebug) {
+            throw new InvalidArgumentException(sprintf('isDebug should be boolean, got %s', gettype($isDebug)));
         }
 
         return new self($traceId, $spanId, $parentId, $isSampled, $isDebug, $usesTraceId128bits);
@@ -236,14 +243,5 @@ final class TraceContext implements SamplingFlags
             && $this->isSampled === $samplingFlags->isSampled
             && $this->isDebug === $samplingFlags->isDebug
             && $this->usesTraceId128bits === $samplingFlags->usesTraceId128bits;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return $this->isSampled === self::EMPTY_SAMPLED
-            && $this->isDebug === self::EMPTY_DEBUG;
     }
 }

--- a/tests/Integration/Reporters/Http/CurlFactoryTest.php
+++ b/tests/Integration/Reporters/Http/CurlFactoryTest.php
@@ -12,6 +12,9 @@ use Zipkin\Reporters\Http\CurlFactory;
 
 final class CurlFactoryTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @requires PHP 7.0
+     */
     public function testHttpReportingSuccess()
     {
         $t = $this;
@@ -47,6 +50,9 @@ final class CurlFactoryTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testHttpReportingFailsDueToInvalidStatusCode()
     {
         $server = HttpTestServer::create(

--- a/tests/Unit/NoopSpanTest.php
+++ b/tests/Unit/NoopSpanTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ZipkinTests\Unit;
+
+use PHPUnit_Framework_TestCase;
+use Zipkin\NoopSpan;
+use Zipkin\Propagation\TraceContext;
+
+final class NoopSpanTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreateNoopSpanSuccess()
+    {
+        $context = TraceContext::createAsRoot();
+        $span = NoopSpan::create($context);
+        $this->assertTrue($span instanceof NoopSpan);
+    }
+}

--- a/tests/Unit/Propagation/B3Test.php
+++ b/tests/Unit/Propagation/B3Test.php
@@ -56,7 +56,7 @@ final class B3Test extends PHPUnit_Framework_TestCase
         $samplingFlags = $extractor($carrier);
 
         $this->assertInstanceOf(DefaultSamplingFlags::class, $samplingFlags);
-        $this->assertTrue($samplingFlags->isEmpty());
+        $this->assertNull($samplingFlags->isSampled());
     }
 
     /**
@@ -64,7 +64,7 @@ final class B3Test extends PHPUnit_Framework_TestCase
      */
     public function testExtractorExtractsTheExpectedValuesForSamplingDebug($carrier)
     {
-        $isSampled = $this->randomBool();
+        $isSampled = $this->randomBoolean();
 
         $carrier[strtolower(self::SAMPLED_NAME)] = $isSampled;
         $carrier[strtolower(self::FLAGS_NAME)] = '1';
@@ -83,7 +83,7 @@ final class B3Test extends PHPUnit_Framework_TestCase
      */
     public function testExtractorExtractsTheExpectedValuesForSampling($carrier)
     {
-        $isSampled = $this->randomBool();
+        $isSampled = $this->randomBoolean();
 
         $carrier[strtolower(self::TRACE_ID_NAME)] = self::TEST_TRACE_ID;
         $carrier[strtolower(self::SAMPLED_NAME)] = $isSampled ? '1' : '0';
@@ -126,7 +126,7 @@ final class B3Test extends PHPUnit_Framework_TestCase
         ];
     }
 
-    private function randomBool()
+    private function randomBoolean()
     {
         return (mt_rand(0, 1) === 1);
     }

--- a/tests/Unit/Propagation/TraceContextTest.php
+++ b/tests/Unit/Propagation/TraceContextTest.php
@@ -20,6 +20,8 @@ final class TraceContextTest extends PHPUnit_Framework_TestCase
     const TEST_INVALID_PARENT_ID = 'invalid_bd7a977555f6b982';
     const TEST_INVALID_SPAN_ID = 'invalid_be2d01e33cc78d97';
 
+    const IS_FINAL_MUTATION = true;
+
     private $hasAtLeastOneMutation;
 
     protected function setUp()
@@ -193,7 +195,7 @@ final class TraceContextTest extends PHPUnit_Framework_TestCase
             $this->maybeMutate(self::TEST_SPAN_ID),
             $this->maybeMutate(self::TEST_PARENT_ID),
             $this->maybeMutate($sampled),
-            $this->maybeMutate($debug, true)
+            $this->maybeMutate($debug, self::IS_FINAL_MUTATION)
         );
 
         $traceContext2 = TraceContext::create(
@@ -207,16 +209,6 @@ final class TraceContextTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($traceContext1->isEqual($traceContext2));
     }
 
-    /**
-     * @dataProvider boolProvider
-     */
-    public function testIsEmptyOnExpectedValues($sampled, $debug)
-    {
-        $samplingFlags = DefaultSamplingFlags::create($sampled, $debug);
-        $context = TraceContext::createAsRoot($samplingFlags);
-        $this->assertEquals($sampled === self::EMPTY_SAMPLED && $debug === self::EMPTY_DEBUG, $context->isEmpty());
-    }
-
     public function boolProvider()
     {
         return [
@@ -227,9 +219,9 @@ final class TraceContextTest extends PHPUnit_Framework_TestCase
         ];
     }
 
-    private function maybeMutate($value, $final = false)
+    private function maybeMutate($value, $isFinalMutation = false)
     {
-        if ($final && !$this->hasAtLeastOneMutation) {
+        if ($isFinalMutation && !$this->hasAtLeastOneMutation) {
             $shouldMutate = true;
         } else {
             $shouldMutate = (bool) mt_rand(0, 1);


### PR DESCRIPTION
This PR fixes a couple of details in order to make consistent the creation of new traces using `nextSpan`.

Ping @cc5092