### PR TITLE
Removes try/catch in HTTP reporter.

### DIFF
--- a/src/Zipkin/Reporters/Http.php
+++ b/src/Zipkin/Reporters/Http.php
@@ -22,22 +22,15 @@ final class Http implements Reporter
     private $clientFactory;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @var array
      */
     private $options;
 
     public function __construct(
         ClientFactory $requesterFactory = null,
-        LoggerInterface $logger = null,
         array $options = []
     ) {
         $this->clientFactory = $requesterFactory ?: CurlFactory::create();
-        $this->logger = $logger ?: new NullLogger() ;
         $this->options = array_merge(self::DEFAULT_OPTIONS, $options);
     }
 
@@ -51,13 +44,7 @@ final class Http implements Reporter
             return $span->toArray();
         }, $spans));
 
-        try {
-            $client = $this->clientFactory->build($this->options);
-            $client($payload);
-        } catch (Exception $e) {
-            $this->logger->error(
-                sprintf('Failed to report spans: %s', $e->getMessage())
-            );
-        }
+        $client = $this->clientFactory->build($this->options);
+        $client($payload);
     }
 }


### PR DESCRIPTION
Currently we catch any reporting exception and drop a log record for it but following most common approach we should propagate the exception and let the client decide what to do with it (ex. ignore the error, send a metric, etc.). This PR is not a breaking change but could break clients not doing `try/catch` when reporting.

Ping @adriancole @cc5092 @felixfbecker