### PR TITLE
Adds support for reporter metrics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
 
 install:
   - composer install

--- a/src/Zipkin/Reporters/Http.php
+++ b/src/Zipkin/Reporters/Http.php
@@ -45,12 +45,12 @@ final class Http implements Reporter
      */
     public function report(array $spans)
     {
-        $this->reportMetrics->incrementSpans(count($spans));
-        $this->reportMetrics->incrementMessages();
-
         $payload = json_encode(array_map(function (Span $span) {
             return $span->toArray();
         }, $spans));
+
+        $this->reportMetrics->incrementSpans(count($spans));
+        $this->reportMetrics->incrementMessages();
 
         $payloadLength = strlen($payload);
         $this->reportMetrics->incrementSpanBytes($payloadLength);

--- a/src/Zipkin/Reporters/InMemoryMetrics.php
+++ b/src/Zipkin/Reporters/InMemoryMetrics.php
@@ -7,7 +7,12 @@ final class InMemoryMetrics implements Metrics
     /**
      * @var int
      */
-    private $incrementedSpans = 0;
+    private $spansCount = 0;
+
+    /**
+     * @var int
+     */
+    private $spanBytesCount = 0;
 
     /**
      * @var int
@@ -15,16 +20,41 @@ final class InMemoryMetrics implements Metrics
     private $spansDroppedCount = 0;
 
     /**
+     * @var int
+     */
+    private $messagesCount = 0;
+
+    /**
+     * @var int
+     */
+    private $messagesDroppedCount = 0;
+
+    /**
+     * @var int
+     */
+    private $messageBytes = 0;
+
+    /**
+     * @var int
+     */
+    private $queuedSpans = 0;
+
+    /**
+     * @var int
+     */
+    private $queuedBytes = 0;
+
+    /**
      * {@inheritdoc}
      */
     public function incrementSpans($quantity)
     {
-        $this->incrementedSpans += $quantity;
+        $this->spansCount += $quantity;
     }
 
     public function getSpans()
     {
-        return $this->incrementedSpans;
+        return $this->spansCount;
     }
 
     /**
@@ -38,5 +68,83 @@ final class InMemoryMetrics implements Metrics
     public function getSpansDropped()
     {
         return $this->spansDroppedCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpanBytes($quantity)
+    {
+        $this->spanBytesCount += $quantity;
+    }
+
+    public function getSpanBytes()
+    {
+        return $this->spanBytesCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessages()
+    {
+        $this->messagesCount++;
+    }
+
+    public function getMessages()
+    {
+        return $this->messagesCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessagesDropped($cause)
+    {
+        $this->messagesDroppedCount++;
+    }
+
+    public function getMessagesDropped()
+    {
+        return $this->messagesDroppedCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessageBytes($quantity)
+    {
+        $this->messageBytes += $quantity;
+    }
+
+    public function getMessageBytes()
+    {
+        return $this->messageBytes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateQueuedSpans($update)
+    {
+        $this->queuedSpans = $update;
+    }
+
+    public function getQueuedSpans()
+    {
+        return $this->queuedSpans;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateQueuedBytes($update)
+    {
+        $this->queuedBytes = $update;
+    }
+
+    public function getQueuedBytes()
+    {
+        return $this->queuedBytes;
     }
 }

--- a/src/Zipkin/Reporters/InMemoryMetrics.php
+++ b/src/Zipkin/Reporters/InMemoryMetrics.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Zipkin\Reporters;
+
+final class InMemoryMetrics implements Metrics
+{
+    /**
+     * @var int
+     */
+    private $incrementedSpans = 0;
+
+    /**
+     * @var int
+     */
+    private $spansDroppedCount = 0;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpans($quantity)
+    {
+        $this->incrementedSpans += $quantity;
+    }
+
+    public function getSpans()
+    {
+        return $this->incrementedSpans;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpansDropped($quantity)
+    {
+        $this->spansDroppedCount += $quantity;
+    }
+
+    public function getSpansDropped()
+    {
+        return $this->spansDroppedCount;
+    }
+}

--- a/src/Zipkin/Reporters/Metrics.php
+++ b/src/Zipkin/Reporters/Metrics.php
@@ -17,14 +17,34 @@ namespace Zipkin\Reporters;
  *
  * <h3>Key Relationships</h3>
  *
- * <p>The following relationships can be used to consider health of the tracing system.</p>
+ * <p>The following relationships can be used to consider health of the tracing system.
+ * <pre>
  * <ul>
+ * <li>{@link #updateQueuedSpans Pending spans}. Alert when this increases over time as it could
+ * lead to dropped spans.
  * <li>Dropped spans = Alert when this increases as it could indicate a queue backup.
+ * <li>Successful Messages = {@link #incrementMessages() Accepted messages} -
+ * {@link #incrementMessagesDropped Dropped messages}. Alert when this is more than amount of
+ * messages received from collectors.</li>
  * </li>
  * </ul>
+ * </pre>
  */
 interface Metrics
 {
+    /**
+     * Increments count of message attempts, which contain 1 or more spans. Ex POST requests or Kafka
+     * messages sent.
+     */
+    public function incrementMessages();
+
+    /**
+     * Increments count of messages that could not be sent. Ex host unavailable, or peer disconnect.
+     * @param \Throwable|\Exception $cause
+     * @return void
+     */
+    public function incrementMessagesDropped($cause);
+
     /**
      * Increments the count of spans reported. When {@link AsyncReporter} is used, reported spans will
      * usually be a larger number than messages.
@@ -35,6 +55,24 @@ interface Metrics
     public function incrementSpans($quantity);
 
     /**
+     * Increments the number of encoded span bytes reported.
+     * @param int $quantity
+     * @return void
+     */
+    public function incrementSpanBytes($quantity);
+
+    /**
+     * Increments the number of bytes containing encoded spans in a message.
+     *
+     * <p>This is a function of span bytes per message and overhead</p>
+     *
+     * @see Sender#messageSizeInBytes
+     * @param $quantity
+     * @return void
+     */
+    public function incrementMessageBytes($quantity);
+
+    /**
      * Increments the count of spans dropped for any reason. For example, failure queueing or
      * sending.
      *
@@ -42,4 +80,20 @@ interface Metrics
      * @return void
      */
     public function incrementSpansDropped($quantity);
+
+    /**
+     * Updates the count of spans pending, following a flush activity.
+     *
+     * @param int $update
+     * @return void
+     */
+    public function updateQueuedSpans($update);
+
+    /**
+     * Updates the count of encoded span bytes pending, following a flush activity.
+     *
+     * @param int $update
+     * @return void
+     */
+    public function updateQueuedBytes($update);
 }

--- a/src/Zipkin/Reporters/Metrics.php
+++ b/src/Zipkin/Reporters/Metrics.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zipkin\Reporters;
+
+/**
+ * Instrumented applications report spans over a transport such as Kafka to Zipkin Collectors.
+ *
+ * <p>Callbacks on this type are invoked by zipkin reporters to improve the visibility of the
+ * system. A typical implementation will report metrics to a telemetry system for analysis and
+ * reporting.</p>
+ *
+ * <h3>Spans Reported vs Queryable Spans</h3>
+ *
+ * <p>A span in the context of reporting is <= span in the context of query. Instrumentation should
+ * report a span only once except, but certain types of spans cross the network. For example, RPC
+ * spans are reported at the client and the server separately.</p>
+ *
+ * <h3>Key Relationships</h3>
+ *
+ * <p>The following relationships can be used to consider health of the tracing system.</p>
+ * <ul>
+ * <li>Dropped spans = Alert when this increases as it could indicate a queue backup.
+ * </li>
+ * </ul>
+ */
+interface Metrics
+{
+    /**
+     * Increments the count of spans reported. When {@link AsyncReporter} is used, reported spans will
+     * usually be a larger number than messages.
+     *
+     * @param int $quantity
+     * @return void
+     */
+    public function incrementSpans($quantity);
+
+    /**
+     * Increments the count of spans dropped for any reason. For example, failure queueing or
+     * sending.
+     *
+     * @param int $quantity
+     * @return void
+     */
+    public function incrementSpansDropped($quantity);
+}

--- a/src/Zipkin/Reporters/NoopMetrics.php
+++ b/src/Zipkin/Reporters/NoopMetrics.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zipkin\Reporters;
+
+final class NoopMetrics implements Metrics
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpans($quantity)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpansDropped($quantity)
+    {
+    }
+}

--- a/src/Zipkin/Reporters/NoopMetrics.php
+++ b/src/Zipkin/Reporters/NoopMetrics.php
@@ -17,4 +17,46 @@ final class NoopMetrics implements Metrics
     public function incrementSpansDropped($quantity)
     {
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessages()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessagesDropped($cause)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementSpanBytes($quantity)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementMessageBytes($quantity)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateQueuedSpans($update)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateQueuedBytes($update)
+    {
+    }
 }

--- a/tests/Unit/Reporters/HttpMockFactory.php
+++ b/tests/Unit/Reporters/HttpMockFactory.php
@@ -2,11 +2,35 @@
 
 namespace ZipkinTests\Unit\Reporters;
 
+use RuntimeException;
 use Zipkin\Reporters\Http\ClientFactory;
 
 final class HttpMockFactory implements ClientFactory
 {
+    /**
+     * @var string
+     */
     private $content;
+
+    /**
+     * @var bool
+     */
+    private $shouldFail;
+
+    private function __construct($shouldFail)
+    {
+        $this->shouldFail = $shouldFail;
+    }
+
+    public static function createAsSuccess()
+    {
+        return new self(false);
+    }
+
+    public static function createAsFailing()
+    {
+        return new self(true);
+    }
 
     /**
      * @param array $options
@@ -16,7 +40,11 @@ final class HttpMockFactory implements ClientFactory
     {
         $self = $this;
 
-        return function ($payload) use ($self) {
+        return function ($payload) use (&$self) {
+            if ($self->shouldFail) {
+                throw new RuntimeException('Failed to report over http.');
+            }
+
             $self->content = $payload;
         };
     }

--- a/tests/Unit/Reporters/InMemoryMetricsTest.php
+++ b/tests/Unit/Reporters/InMemoryMetricsTest.php
@@ -7,17 +7,24 @@ use Zipkin\Reporters\InMemoryMetrics;
 
 final class InMemoryMetricsTest extends PHPUnit_Framework_TestCase
 {
-    public function testIncrementSpansSuccess()
+    public function testMetricsSpansSuccess()
     {
         $metrics = new InMemoryMetrics();
-        $metrics->incrementSpans(10);
-        $this->assertEquals(10, $metrics->getSpans());
-    }
-
-    public function testIncrementSpansDroppedSuccess()
-    {
-        $metrics = new InMemoryMetrics();
-        $metrics->incrementSpansDropped(10);
-        $this->assertEquals(10, $metrics->getSpansDropped());
+        $metrics->incrementSpans(1);
+        $metrics->incrementSpansDropped(2);
+        $metrics->incrementSpanBytes(3);
+        $metrics->incrementMessages();
+        $metrics->incrementMessagesDropped(new \Exception);
+        $metrics->incrementMessageBytes(4);
+        $metrics->updateQueuedSpans(5);
+        $metrics->updateQueuedBytes(6);
+        $this->assertEquals(1, $metrics->getSpans());
+        $this->assertEquals(2, $metrics->getSpansDropped());
+        $this->assertEquals(3, $metrics->getSpanBytes());
+        $this->assertEquals(1, $metrics->getMessages());
+        $this->assertEquals(1, $metrics->getMessagesDropped());
+        $this->assertEquals(4, $metrics->getMessageBytes());
+        $this->assertEquals(5, $metrics->getQueuedSpans());
+        $this->assertEquals(6, $metrics->getQueuedBytes());
     }
 }

--- a/tests/Unit/Reporters/InMemoryMetricsTest.php
+++ b/tests/Unit/Reporters/InMemoryMetricsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZipkinTests\Unit\Reporters;
+
+use PHPUnit_Framework_TestCase;
+use Zipkin\Reporters\InMemoryMetrics;
+
+final class InMemoryMetricsTest extends PHPUnit_Framework_TestCase
+{
+    public function testIncrementSpansSuccess()
+    {
+        $metrics = new InMemoryMetrics();
+        $metrics->incrementSpans(10);
+        $this->assertEquals(10, $metrics->getSpans());
+    }
+
+    public function testIncrementSpansDroppedSuccess()
+    {
+        $metrics = new InMemoryMetrics();
+        $metrics->incrementSpansDropped(10);
+        $this->assertEquals(10, $metrics->getSpansDropped());
+    }
+}

--- a/tests/Unit/Reporters/NoopMetricsTest.php
+++ b/tests/Unit/Reporters/NoopMetricsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZipkinTests\Unit\Reporters;
+
+use PHPUnit_Framework_TestCase;
+use Zipkin\Reporters\Metrics;
+use Zipkin\Reporters\NoopMetrics;
+
+final class NoopMetricsTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreateNoopMetricsSuccess()
+    {
+        $noopMetrics = new NoopMetrics();
+        $this->assertInstanceOf(Metrics::class, $noopMetrics);
+    }
+}

--- a/tests/Unit/Reporters/NoopTest.php
+++ b/tests/Unit/Reporters/NoopTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ZipkinTests\Unit\Reporters;
+
+use PHPUnit_Framework_TestCase;
+use Zipkin\Reporter;
+use Zipkin\Reporters\Noop;
+
+final class NoopTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreateNoopReporterSuccess()
+    {
+        $noopReporter = new Noop();
+        $this->assertInstanceOf(Reporter::class, $noopReporter);
+    }
+}


### PR DESCRIPTION
This PR adds the interface for reporter metrics. Reporter metrics is the contract for handling with reporting failures (for example: server not available, failure over network, etc.)

The reason for https://github.com/jcchavezs/zipkin-php/compare/adds_support_for_reporter_metrics?expand=1#diff-542892a2dd974b841a279a65f6b8c93aR35 is to keep retro compatibility.

Ping @adriancole @eligijusvitkauskas-home24  @cc5092

Closes #64