### PR TITLE
Change SpanMap::getHash() to crc32() to reduce hash collisions

### DIFF
--- a/src/Zipkin/Recording/SpanMap.php
+++ b/src/Zipkin/Recording/SpanMap.php
@@ -85,6 +85,6 @@ final class SpanMap
      */
     private function getHash(TraceContext $context)
     {
-        return spl_object_hash($context);
+        return crc32($context->getSpanId() . ($context->getParentId() ? $context->getParentId() : "-") . $context->getTraceId());
     }
 }

--- a/src/Zipkin/Recording/SpanMap.php
+++ b/src/Zipkin/Recording/SpanMap.php
@@ -85,6 +85,6 @@ final class SpanMap
      */
     private function getHash(TraceContext $context)
     {
-        return crc32($context->getSpanId() . ($context->getParentId() ? $context->getParentId() : "-") . $context->getTraceId());
+        return crc32($context->getSpanId() . $context->getTraceId());
     }
 }

--- a/tests/Unit/Recording/SpanMapTest.php
+++ b/tests/Unit/Recording/SpanMapTest.php
@@ -44,7 +44,7 @@ final class SpanMapTest extends PHPUnit_Framework_TestCase
             $recordedSpans[$i] = $spanMap->getOrCreate($context, $endpoint);
         }
         for ($i = 0; $i < count($recordedSpans); $i++) {
-            for($j = $i + 1; $j < count($recordedSpans); $j++) {
+            for ($j = $i + 1; $j < count($recordedSpans); $j++) {
                 $this->assertNotSame($recordedSpans[$i], $recordedSpans[$j]);
             }
         }
@@ -67,7 +67,7 @@ final class SpanMapTest extends PHPUnit_Framework_TestCase
         $numberOfContexts = 3;
 
         for ($i = 0; $i < $numberOfContexts; $i++) {
-            $contexts[$i] = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
+            $contexts[$i] = TraceContext::createAsRoot();
             $endpoint = Endpoint::createAsEmpty();
             $spanMap->getOrCreate($contexts[$i], $endpoint);
         }

--- a/tests/Unit/Recording/SpanMapTest.php
+++ b/tests/Unit/Recording/SpanMapTest.php
@@ -33,6 +33,23 @@ final class SpanMapTest extends PHPUnit_Framework_TestCase
         $this->assertNull($spanMap->get($context));
     }
 
+    public function testGetReturnsDifferentObjects()
+    {
+        $spanMap = SpanMap::create();
+        $endpoint = Endpoint::createAsEmpty();
+        $rootSpan = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
+        $recordedSpans = [];
+        for ($i = 0; $i < 5; $i++) {
+            $context = TraceContext::createFromParent($rootSpan);
+            $recordedSpans[$i] = $spanMap->getOrCreate($context, $endpoint);
+        }
+        for ($i = 0; $i < count($recordedSpans); $i++) {
+            for($j = $i + 1; $j < count($recordedSpans); $j++) {
+                $this->assertNotSame($recordedSpans[$i], $recordedSpans[$j]);
+            }
+        }
+    }
+
     public function testRemoveReturnsEmptyAfterRemoval()
     {
         $spanMap = SpanMap::create();


### PR DESCRIPTION
Change \Zipkin\Recording\SpanMap::getHash() to crc32() to reduce hash collisions.

As discussed in https://github.com/jcchavezs/zipkin-php/issues/76, spl_object_hash() can produce hash collisions when the PHP garbage collectors cleans up destroyed spans.

This changes the getHash() function from spl_object_hash() to a crc32() hash of the spanId, traceId and parentId.