### PR TITLE
Set CURLOPT_RETURNTRANSFER to true 

### DIFF
--- a/src/Zipkin/Reporters/Http/CurlFactory.php
+++ b/src/Zipkin/Reporters/Http/CurlFactory.php
@@ -42,6 +42,7 @@ final class CurlFactory implements ClientFactory
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($payload),
             ]);
+            curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
 
             if (curl_exec($handle) === true) {
                 $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);

--- a/src/Zipkin/Reporters/Http/CurlFactory.php
+++ b/src/Zipkin/Reporters/Http/CurlFactory.php
@@ -44,7 +44,7 @@ final class CurlFactory implements ClientFactory
             ]);
             curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
 
-            if (curl_exec($handle) === true) {
+            if (curl_exec($handle) !== false) {
                 $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
                 curl_close($handle);
 


### PR DESCRIPTION
So that the string value of the transfer is returned rather than outputting it directly.