### PR TITLE
Enhancement: Reference phpunit schema as installed with composer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         backupGlobals="true"
         backupStaticAttributes="false"
         bootstrap="./vendor/autoload.php"


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`

💁‍♂️ This way it will always refer to the appropriate schema.